### PR TITLE
chore: add required GitHub Actions permissions

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+permissions:
+  contents: write
+  security-events: read
 
 jobs:
   build:
@@ -34,7 +37,10 @@ jobs:
       - name: Pack and Push NuGet Packages
         uses: simplify9/.github/.github/actions/dotnet-pack-push@main
         with:
-          projects: "SW.Scheduler.Sdk/SW.Scheduler.Sdk.csproj SW.Scheduler/SW.Scheduler.csproj SW.Scheduler.EfCore/SW.Scheduler.EfCore.csproj SW.Scheduler.PgSql/SW.Scheduler.PgSql.csproj SW.Scheduler.SqlServer/SW.Scheduler.SqlServer.csproj SW.Scheduler.MySql/SW.Scheduler.MySql.csproj SW.Scheduler.Viewer/SW.Scheduler.Viewer.csproj"
+          projects: "SW.Scheduler.Sdk/SW.Scheduler.Sdk.csproj SW.Scheduler/SW.Scheduler.csproj
+            SW.Scheduler.EfCore/SW.Scheduler.EfCore.csproj SW.Scheduler.PgSql/SW.Scheduler.PgSql.csproj
+            SW.Scheduler.SqlServer/SW.Scheduler.SqlServer.csproj SW.Scheduler.MySql/SW.Scheduler.MySql.csproj
+            SW.Scheduler.Viewer/SW.Scheduler.Viewer.csproj"
           configuration: "Release"
           version: ${{ steps.semver.outputs.version }}
           api-key: ${{ secrets.SWNUGETKEY }}


### PR DESCRIPTION
Ensures every GitHub Actions workflow on `main` has:

```yaml
permissions:
  contents: write
  security-events: read
```

Existing unrelated permission entries are preserved.

Existing job-level permission overrides are also updated so they do not override and remove the required workflow permissions.

No triggers, jobs, steps, deployment environments, or push branch lists are intentionally changed.